### PR TITLE
Use types from std namespace

### DIFF
--- a/types.hpp
+++ b/types.hpp
@@ -1,8 +1,8 @@
 #include <cstdint>
 
-using u8 = uint8_t;
-using u16 = uint16_t;
-using u32 = uint32_t;
-using s8 = int8_t;
-using s16 = int16_t;
-using s32 = int32_t;
+using u8 = std::uint8_t;
+using u16 = std::uint16_t;
+using u32 = std::uint32_t;
+using s8 = std::int8_t;
+using s16 = std::int16_t;
+using s32 = std::int32_t;


### PR DESCRIPTION
It's better to specify the `std` namespace for these.

The standard says that `uint8_t` et al are defined in the `std` namespace, but says nothing about whether they are present in the global namespace (despite that being common practice).

§17.6.1.3/4 (ISO/IEC 14882:2011(E), C++11):
> Except as noted in Clauses 18 through 30 and Annex D, the contents of each header cname shall be the same as that of the corresponding header name.h, as specified in the C standard library (1.2) or the C Unicode TR, as appropriate, as if by inclusion. **In the C++ standard library, however, the declarations (except for names which are defined as macros in C) are within namespace scope (3.3.6) of the namespace std. It is unspecified whether these names are first declared within the global namespace scope and are then injected into namespace std by explicit using-declarations (7.3.3).**

(Emphasis mine.)